### PR TITLE
Added muted input

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 #### What kind of change does this PR introduce? (check one with "x")
 - [ ] Bugfix
-- [x] Feature
+- [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
@@ -11,16 +11,16 @@
 
 
 #### What is the current behavior? (You can also link to an open issue here)
-no possibility to start the video muted
+
 
 
 #### What is the new behavior?
-after setting muted input as true it starts video with no sound  
+
 
 
 #### Does this PR introduce a breaking change? (check one with "x")
 - [ ] Yes
-- [x] No
+- [ ] No
 
 
 _If this PR contains a breaking change, please describe the impact and migration path for existing applications:_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 #### What kind of change does this PR introduce? (check one with "x")
 - [ ] Bugfix
-- [ ] Feature
+- [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
@@ -11,16 +11,16 @@
 
 
 #### What is the current behavior? (You can also link to an open issue here)
-
+no possibility to start the video muted
 
 
 #### What is the new behavior?
-
+after setting muted input as true it starts video with no sound  
 
 
 #### Does this PR introduce a breaking change? (check one with "x")
 - [ ] Yes
-- [ ] No
+- [x] No
 
 
 _If this PR contains a breaking change, please describe the impact and migration path for existing applications:_

--- a/src/app/video/video.component.html
+++ b/src/app/video/video.component.html
@@ -4,7 +4,7 @@
     </div>
 
     <video #video class="video" [attr.src]="src ? src : null" [attr.autoplay]="autoplay ? true : null" [preload]="preload ? 'auto' : 'metadata'"
-        [attr.poster]="poster ? poster : null" [attr.loop]="loop ? loop : null">
+        [attr.poster]="poster ? poster : null" [attr.loop]="loop ? loop : null" [attr.muted]="muted ? muted : null">
         <ng-content select="source"></ng-content>
         <ng-content select="track"></ng-content>
         This browser does not support HTML5 video.

--- a/src/app/video/video.component.ts
+++ b/src/app/video/video.component.ts
@@ -26,6 +26,7 @@ export class MatVideoComponent implements AfterViewInit, OnDestroy {
     @Input() poster: string = null;
     @Input() keyboard: boolean = true;
     @Input() overlay: boolean = null;
+    @Input() muted: boolean = null;
 
     playing: boolean = false;
 


### PR DESCRIPTION
The mat-video does not include "muted" attribute for now.
this PR implements that to start the video muted when needed.