### PR TITLE
srcObject support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A slightly more customized example, in your HTML file:
 ## API
 Attribute | Type | Description | Default
 --- | --- | --- | ---
-*src* | **string** | Path or URL to a video | *null*
+*src* | **string|MediaStream|MediaSource|Blob** | Path, URL, or `srcObject` for a video | *null*
 *title* | **string** | Title for the video | *null*
 *autoplay* | **boolean** | Whether the video should autoplay | *false*
 *preload* | **boolean** | Whether the video should preload | *true*

--- a/src/app/video/video.component.html
+++ b/src/app/video/video.component.html
@@ -3,7 +3,7 @@
         {{title}}
     </div>
 
-    <video #video class="video" [attr.src]="src ? src : null" [attr.autoplay]="autoplay ? true : null"
+    <video #video class="video" [attr.autoplay]="autoplay ? true : null"
         [preload]="preload ? 'auto' : 'metadata'" [attr.poster]="poster ? poster : null"
         [attr.loop]="loop ? loop : null">
         <ng-content select="source"></ng-content>

--- a/src/app/video/video.component.ts
+++ b/src/app/video/video.component.ts
@@ -179,6 +179,8 @@ export class MatVideoComponent implements AfterViewInit, OnChanges, OnDestroy {
             this.srcObjectURL = URL.createObjectURL(src);
             this.video.nativeElement.src = this.srcObjectURL;
         }
+
+        this.video.nativeElement.muted = this.muted;
     }
 
 }


### PR DESCRIPTION
`URL.createObjectURL` on `MediaStream` objects was deprecated and removed from browsers a while back, so without this there's no way to support passing a `MediaStream` into mat-video.