### PR TITLE
Remove icons.css component import

### DIFF
--- a/src/app/video/video.component.ts
+++ b/src/app/video/video.component.ts
@@ -17,7 +17,7 @@ import { EventService } from './services/event.service';
 @Component({
     selector: 'mat-video',
     templateUrl: './video.component.html',
-    styleUrls: ['./video.component.css', './styles/icons.css']
+    styleUrls: ['./video.component.css']
 })
 export class MatVideoComponent implements AfterViewInit, OnDestroy {
     @ViewChild('player') private player: ElementRef;


### PR DESCRIPTION
Not necessarily a bug fix, but something to consider. Anyone relying on Material should already have the icons imported in some way, and doing it this specific way may be a redundant use of bandwidth (or, as in my case, cause a Content Security Policy error).