### PR TITLE
Fix Safari stuck on image bug

### DIFF
--- a/projects/mat-video/src/lib/video.component.ts
+++ b/projects/mat-video/src/lib/video.component.ts
@@ -60,10 +60,10 @@ export class MatVideoComponent implements AfterViewInit, OnChanges, OnDestroy {
       if (val < 0) {
         val = 0;
       }
-      if (val !== video.currentTime) {
+      if (Math.abs(val - video.currentTime) > 0.0001) {
         video.currentTime = val;
       }
-      if (this.lastTime !== video.currentTime) {
+      if (Math.abs(this.lastTime - video.currentTime) > 0.0001) {
         setTimeout(() => this.timeChange.emit(video.currentTime), 0);
         this.lastTime = video.currentTime;
       }


### PR DESCRIPTION
The way the player is designed there is a sort of circular dependency when we read the time and then update the player. To break this loop we make sure to update currentTime only if a new value is present. This works well on all browser except safari that get value almost identical. The delta is sub millisecond.

This PR fix the issue mentionned https://github.com/nkoehler/mat-video/issues/37 by only updating the time if we moved by more than a tenth of a millisecond